### PR TITLE
Hotfix

### DIFF
--- a/src/Providers/PayfortServiceProvider.php
+++ b/src/Providers/PayfortServiceProvider.php
@@ -26,8 +26,6 @@ class PayfortServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        parent::boot();
-
         # Add config file to service provider publish command
         $this->publishes([
             $this->configPath => config_path('payfort.php'),


### PR DESCRIPTION
parent::boot() no longer required as of Laravel 5.3